### PR TITLE
指定した字数の文字を作るやつ：不正な値を入力しても、実行ボタンが押せていた

### DIFF
--- a/pages/string-generator.vue
+++ b/pages/string-generator.vue
@@ -59,7 +59,8 @@ const labelClass = 'label cursor-pointer';
 const buttonClass = 'w-40 mt-4';
 
 const isInvalidExecute = computed(() => {
-  return !charType.value || charCount.value === 0;
+  const isNumber = !isNaN(charCount.value) && Number.isInteger(charCount.value);
+  return !charType.value || charCount.value === 0 || !isNumber;
 });
 
 const isOutputEmpty = computed(() => {
@@ -71,6 +72,10 @@ const isHalf = computed(() => {
 });
 
 const execute = (() => {
+  if (isInvalidExecute.value) {
+    alert('数値を指定してください！');
+    return;
+  }
   switch (charType.value) {
     case 'number':
       generateCharacters(isHalf.value ? 'numberHalf' : 'numberFull');


### PR DESCRIPTION
- 不正な値とは
  - 英字や小数など
- `type="number"` を書いているが、ペーストでアルファベットが入力できてしまう
- 小数は普通に入力できる

## 対応
- 整数でない場合は、実行ボタンを押せないようにする